### PR TITLE
Add card cleaning routine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
 *.pyc
+data/raw/AllPrintings.json

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This project analyzes sentiment in Magic: The Gathering card flavor text. The
 workflow is split into several stages:
 
 1. **Data acquisition** (`src/acquisition.py`)
-2. **Cleaning & normalization** (`src/cleaning.py`)
+2. **Cleaning & normalization** (`src/cleaning.py` – see `clean_cards`)
 3. **Sentiment scoring** (`src/sentiment.py`)
 4. **Aggregation** (`src/aggregation.py`)
 5. **Visualization** (`src/visualization.py`)

--- a/src/acquisition.py
+++ b/src/acquisition.py
@@ -2,13 +2,22 @@
 
 from pathlib import Path
 import json
+from typing import List, Dict
+
+from .cleaning import clean_cards
 
 
-def load_cards(json_file: Path) -> list:
+def load_cards(json_file: Path) -> List[Dict]:
     """Load card data from a JSON file and filter entries with flavor text."""
     with open(json_file, "r", encoding="utf-8") as fh:
         cards = json.load(fh)
     return [card for card in cards if card.get("flavorText")]
+
+
+def load_and_clean_cards(json_file: Path) -> List[Dict]:
+    """Load cards then apply cleaning routine to relevant fields."""
+    cards = load_cards(json_file)
+    return clean_cards(cards)
 
 
 if __name__ == "__main__":

--- a/src/cleaning.py
+++ b/src/cleaning.py
@@ -1,7 +1,7 @@
 """Text cleaning functions for flavor text analysis."""
 
 import re
-from typing import Iterable
+from typing import Iterable, List, Dict
 
 
 def normalize(text: str) -> str:
@@ -12,6 +12,24 @@ def normalize(text: str) -> str:
 def clean_flavor_texts(texts: Iterable[str]) -> list:
     """Return a list of normalized flavor text strings."""
     return [normalize(t) for t in texts]
+
+
+def clean_cards(cards: Iterable[Dict]) -> List[Dict]:
+    """Filter out cards missing flavor text and normalize relevant fields."""
+    filtered = [c for c in cards if c.get("flavorText")]
+    cleaned_texts = clean_flavor_texts(c["flavorText"] for c in filtered)
+
+    cleaned_cards: List[Dict] = []
+    for card, cleaned_text in zip(filtered, cleaned_texts):
+        cleaned = dict(card)
+        cleaned["flavorText"] = cleaned_text
+        if "name" in cleaned:
+            cleaned["name"] = normalize(cleaned["name"])
+        if "setName" in cleaned:
+            cleaned["setName"] = normalize(cleaned["setName"])
+        cleaned_cards.append(cleaned)
+
+    return cleaned_cards
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- support cleaning of card dictionaries with `clean_cards`
- use new routine in data acquisition helpers
- ignore sample MTGJSON data
- document cleaning routine in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856f91ae944832c9f12c86314d0c884