### PR TITLE
Add scoring script and ensure VADER lexicon download

### DIFF
--- a/scripts/score_flavor_texts.py
+++ b/scripts/score_flavor_texts.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+import sys
+
+# Ensure src package is importable when running this script directly
+repo_root = Path(__file__).resolve().parents[1]
+sys.path.append(str(repo_root))
+
+import pandas as pd
+import nltk
+
+from src.acquisition import load_and_clean_cards
+from src.sentiment import score_texts
+
+
+def main() -> None:
+    # Ensure VADER lexicon is available
+    nltk.download("vader_lexicon")
+
+    cards_path = Path("data/raw/AllPrintings.json")
+    cards = load_and_clean_cards(cards_path)
+
+    texts = [card["flavorText"] for card in cards]
+    scores = score_texts(texts)
+
+    df_cards = pd.DataFrame(cards)
+    df_scores = pd.DataFrame(scores)
+    result = pd.concat([df_cards.reset_index(drop=True), df_scores], axis=1)
+
+    out_path = Path("data/processed/sentiment_scores.csv")
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    result.to_csv(out_path, index=False)
+    print(f"Wrote sentiment scores to {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/sentiment.py
+++ b/src/sentiment.py
@@ -2,6 +2,7 @@
 
 from textblob import TextBlob
 from nltk.sentiment import SentimentIntensityAnalyzer
+import nltk
 from typing import Iterable, Dict
 
 # Initialize VADER analyzer lazily
@@ -12,6 +13,7 @@ def vader() -> SentimentIntensityAnalyzer:
     """Return a singleton VADER analyzer."""
     global _vader
     if _vader is None:
+        nltk.download("vader_lexicon", quiet=True)
         _vader = SentimentIntensityAnalyzer()
     return _vader
 


### PR DESCRIPTION
## Summary
- ensure `vader_lexicon` is downloaded in the sentiment helper
- add `scripts/score_flavor_texts.py` example

## Testing
- `pip install -r requirements.txt`
- `python - <<'EOF'
from src.sentiment import score_texts
print(score_texts(["Happy", "Sad"]))
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6856fb00887c832ca47d50265b7fc8f9