### PR TITLE
Add pipeline script with documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,28 @@ mtg-flavor/
 ```
 
 See `mtg_flavor_text_sentiment_analysis.md` for the full project outline.
+
+## Setup
+
+1. Create a Python environment and install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Download the MTGJSON `AllPrintings.json` dataset from [https://mtgjson.com](https://mtgjson.com) and place it in `data/raw/AllPrintings.json`.
+
+## Running the pipeline
+
+Execute `main.py` to run the workflow end-to-end:
+```bash
+python main.py
+```
+The script will:
+- load and clean card data
+- score flavor text sentiment
+- save results to `data/processed/sentiment_scores.csv`
+- aggregate sentiment by color and save to `data/processed/average_sentiment_by_color.csv`
+- create a chart in `reports/figures/average_polarity_by_color.png`
+
+## Viewing outputs
+
+Check the `data/processed` directory for CSV files containing sentiment scores and aggregates. Generated figures are stored under `reports/figures`.

--- a/main.py
+++ b/main.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+import pandas as pd
+import matplotlib.pyplot as plt
+
+from src.acquisition import load_and_clean_cards
+from src.sentiment import score_texts
+from src.aggregation import by_set, by_color
+from src.visualization import plot_average_sentiment
+
+
+def run_pipeline() -> None:
+    """Run the full sentiment analysis pipeline."""
+    raw_path = Path("data/raw/AllPrintings.json")
+    print(f"Loading cards from {raw_path} ...")
+    cards = load_and_clean_cards(raw_path)
+
+    texts = [card["flavorText"] for card in cards]
+    print("Scoring flavor text ...")
+    scores = score_texts(texts)
+
+    df_cards = pd.DataFrame(cards)
+    df_scores = pd.DataFrame(scores)
+    df = pd.concat([df_cards.reset_index(drop=True), df_scores], axis=1)
+
+    processed_dir = Path("data/processed")
+    processed_dir.mkdir(parents=True, exist_ok=True)
+    scores_path = processed_dir / "sentiment_scores.csv"
+    df.to_csv(scores_path, index=False)
+    print(f"Saved scored data to {scores_path}")
+
+    print("Aggregating results ...")
+    metrics = [
+        "textblob_polarity",
+        "vader_compound",
+        "vader_pos",
+        "vader_neg",
+        "vader_neu",
+    ]
+    df_by_color = by_color(df[["color_identity"] + metrics])
+    agg_path = processed_dir / "average_sentiment_by_color.csv"
+    df_by_color.to_csv(agg_path)
+    print(f"Saved aggregation to {agg_path}")
+
+    print("Generating figure ...")
+    fig_path = Path("reports/figures/average_polarity_by_color.png")
+    fig_path.parent.mkdir(parents=True, exist_ok=True)
+    plot_average_sentiment(df, group="color_identity", metric="textblob_polarity")
+    plt.savefig(fig_path)
+    plt.close()
+    print(f"Saved figure to {fig_path}")
+
+
+if __name__ == "__main__":
+    run_pipeline()


### PR DESCRIPTION
## Summary
- orchestrate full workflow in a new `main.py`
- document setup and pipeline execution in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6856fed20e2c832caa76cd331a582bfe