### PR TITLE
Add unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,10 @@ The script will:
 ## Viewing outputs
 
 Check the `data/processed` directory for CSV files containing sentiment scores and aggregates. Generated figures are stored under `reports/figures`.
+
+## Running tests
+
+Execute the unit test suite with `pytest`:
+```bash
+pytest
+```

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Ensure src package is importable in tests
+repo_root = Path(__file__).resolve().parents[1]
+if str(repo_root) not in sys.path:
+    sys.path.insert(0, str(repo_root))

--- a/tests/test_acquisition.py
+++ b/tests/test_acquisition.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+from src.acquisition import load_cards, load_and_clean_cards
+
+
+def test_load_cards_filters_flavor(tmp_path: Path):
+    sample = Path(__file__).parent / "test_data" / "sample_cards.json"
+    cards = load_cards(sample)
+    # should only include entry with non-empty flavorText
+    assert len(cards) == 1
+    assert cards[0]["name"] == "Card One"
+
+
+def test_load_and_clean_cards_normalizes(tmp_path: Path):
+    sample = Path(__file__).parent / "test_data" / "sample_cards.json"
+    cards = load_and_clean_cards(sample)
+    # expect only one card cleaned and newline removed
+    assert len(cards) == 1
+    assert cards[0]["flavorText"] == "Line one Line two"
+    assert cards[0]["name"] == "Card One"
+    assert cards[0]["setName"] == "Set A"

--- a/tests/test_aggregation.py
+++ b/tests/test_aggregation.py
@@ -1,0 +1,26 @@
+import pytest
+import pandas as pd
+
+from src.aggregation import by_set, by_color
+
+
+def test_by_set_groups_average():
+    df = pd.DataFrame({
+        "set_code": ["A", "A", "B"],
+        "textblob_polarity": [0.1, 0.3, 0.5],
+    })
+    result = by_set(df)
+    result = result.sort_index()
+    assert list(result.index) == ["A", "B"]
+    assert result.loc["A", "textblob_polarity"] == pytest.approx(0.2)
+
+
+def test_by_color_groups_average():
+    df = pd.DataFrame({
+        "color_identity": ["U", "U", "R"],
+        "vader_compound": [0.2, 0.4, 0.6],
+    })
+    result = by_color(df)
+    result = result.sort_index()
+    assert list(result.index) == ["R", "U"]
+    assert result.loc["U", "vader_compound"] == pytest.approx(0.3)

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -1,0 +1,23 @@
+from src.cleaning import normalize, clean_flavor_texts, clean_cards
+
+
+def test_normalize_strips_whitespace():
+    assert normalize("  foo\nbar  ") == "foo bar"
+
+
+def test_clean_flavor_texts_list():
+    texts = ["hello\nworld", "foo"]
+    assert clean_flavor_texts(texts) == ["hello world", "foo"]
+
+
+def test_clean_cards_filters_and_cleans():
+    cards = [
+        {"name": "Name\nOne", "setName": "Set\nOne", "flavorText": "hi\nthere"},
+        {"name": "Name Two"},
+    ]
+    cleaned = clean_cards(cards)
+    assert len(cleaned) == 1
+    c = cleaned[0]
+    assert c["name"] == "Name One"
+    assert c["setName"] == "Set One"
+    assert c["flavorText"] == "hi there"

--- a/tests/test_data/sample_cards.json
+++ b/tests/test_data/sample_cards.json
@@ -1,0 +1,22 @@
+[
+    {
+        "name": "Card One",
+        "setName": "Set A",
+        "flavorText": "Line one\nLine two",
+        "set_code": "SETA",
+        "color_identity": "U"
+    },
+    {
+        "name": "Card Two",
+        "setName": "Set B",
+        "flavorText": "",
+        "set_code": "SETB",
+        "color_identity": "G"
+    },
+    {
+        "name": "Card Three",
+        "setName": "Set C",
+        "set_code": "SETC",
+        "color_identity": "R"
+    }
+]

--- a/tests/test_sentiment.py
+++ b/tests/test_sentiment.py
@@ -1,0 +1,16 @@
+from src.sentiment import score_text, score_texts
+
+
+def test_score_text_returns_scores():
+    result = score_text("I love this game!")
+    assert "textblob_polarity" in result
+    assert "vader_compound" in result
+    assert isinstance(result["textblob_polarity"], float)
+
+
+def test_score_texts_multiple():
+    texts = ["good", "bad"]
+    scores = score_texts(texts)
+    assert isinstance(scores, list)
+    assert len(scores) == 2
+    assert set(scores[0]) == set(scores[1])


### PR DESCRIPTION
## Summary
- add pytest-based tests for modules
- provide sample card data for tests
- document how to run tests in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857092d25e4832cb6b9976b064c037e