### PR TITLE
Fix tests import path when run directly

### DIFF
--- a/tests/test_acquisition.py
+++ b/tests/test_acquisition.py
@@ -1,4 +1,8 @@
 from pathlib import Path
+import sys
+
+# Ensure the src package is importable when running this file directly
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from src.acquisition import load_cards, load_and_clean_cards
 

--- a/tests/test_aggregation.py
+++ b/tests/test_aggregation.py
@@ -1,5 +1,10 @@
 import pytest
 import pandas as pd
+import sys
+from pathlib import Path
+
+# Ensure the src package is importable when running this file directly
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from src.aggregation import by_set, by_color
 

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -1,3 +1,9 @@
+import sys
+from pathlib import Path
+
+# Ensure the src package is importable when running this file directly
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
 from src.cleaning import normalize, clean_flavor_texts, clean_cards
 
 

--- a/tests/test_sentiment.py
+++ b/tests/test_sentiment.py
@@ -1,3 +1,9 @@
+import sys
+from pathlib import Path
+
+# Ensure the src package is importable when running this file directly
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
 from src.sentiment import score_text, score_texts
 
 


### PR DESCRIPTION
## Summary
- ensure tests adjust `sys.path` so `src` is importable when a test file is executed directly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6858059a37fc832c92f966232103bac7