### PR TITLE
Handle missing AllPrintings during run

### DIFF
--- a/main.py
+++ b/main.py
@@ -22,13 +22,21 @@ def download_all_printings(dest: Path) -> None:
     tmp_path.unlink()
 
 
-def run_pipeline() -> None:
+def run_pipeline(raw_path: Path | None = None) -> None:
     """Run the full sentiment analysis pipeline."""
-    raw_path = Path("data/raw/AllPrintings.json")
+    if raw_path is None:
+        raw_path = Path("data/raw/AllPrintings.json")
+
     if not raw_path.is_file():
         download_all_printings(raw_path)
     print(f"Loading cards from {raw_path} ...")
-    cards = load_and_clean_cards(raw_path)
+    try:
+        cards = load_and_clean_cards(raw_path)
+    except FileNotFoundError:
+        # The file may have been removed after the existence check. Re-download
+        # and try again before failing.
+        download_all_printings(raw_path)
+        cards = load_and_clean_cards(raw_path)
 
     texts = [card["flavorText"] for card in cards]
     print("Scoring flavor text ...")

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,51 @@
+import sys
+from pathlib import Path
+import shutil
+import pandas as pd
+
+# Ensure src package importable
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import main
+
+
+def test_run_pipeline_redownloads(tmp_path, monkeypatch):
+    # path where pipeline will expect the JSON file
+    raw_path = tmp_path / "AllPrintings.json"
+
+    # Create an empty file so initial exists check passes
+    raw_path.parent.mkdir(parents=True, exist_ok=True)
+    raw_path.write_text("{}")
+
+    sample = Path(__file__).parent / "test_data" / "sample_cards.json"
+
+    downloads = []
+
+    def fake_download(dest: Path):
+        downloads.append(dest)
+        shutil.copy(sample, dest)
+
+    call_count = {"loads": 0}
+
+    def fake_load_and_clean(path: Path):
+        call_count["loads"] += 1
+        if call_count["loads"] == 1:
+            # Simulate file missing when first attempt occurs
+            path.unlink()
+            raise FileNotFoundError
+        # second attempt should succeed
+        return [{"flavorText": "test", "color_identity": "U"}]
+
+    # patch helpers
+    monkeypatch.setattr(main, "download_all_printings", fake_download)
+    monkeypatch.setattr(main, "load_and_clean_cards", fake_load_and_clean)
+    monkeypatch.setattr(main, "score_texts", lambda texts: [{"textblob_polarity":0, "vader_compound":0,
+                                                             "vader_pos":0, "vader_neg":0, "vader_neu":0} for _ in texts])
+    monkeypatch.setattr(main, "by_color", lambda df: pd.DataFrame())
+    monkeypatch.setattr(main, "plot_average_sentiment", lambda *a, **k: None)
+
+    main.run_pipeline(raw_path=raw_path)
+
+    # ensure download happened once and load attempted twice
+    assert len(downloads) == 1
+    assert call_count["loads"] == 2


### PR DESCRIPTION
## Summary
- redownload AllPrintings.json if it vanishes before loading
- expose `run_pipeline`'s raw path as an argument
- add regression test to ensure the pipeline redownloads the file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685808fda050832ca479117de2488c58