### PR TITLE
Add per-color aggregation

### DIFF
--- a/src/aggregation.py
+++ b/src/aggregation.py
@@ -1,7 +1,7 @@
 """Aggregation helpers for analyzing sentiment statistics."""
 
 import pandas as pd
-from typing import Iterable, Dict
+from typing import Iterable, Dict, List
 
 
 def by_set(df: pd.DataFrame) -> pd.DataFrame:
@@ -12,6 +12,28 @@ def by_set(df: pd.DataFrame) -> pd.DataFrame:
 def by_color(df: pd.DataFrame) -> pd.DataFrame:
     """Return average sentiment metrics grouped by color identity."""
     return df.groupby("color_identity").mean()
+
+
+def by_colors(df: pd.DataFrame) -> pd.DataFrame:
+    """Return average sentiment metrics grouped by individual card color.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        DataFrame containing a ``colors`` column with lists of color letters.
+        Empty lists indicate colorless cards, represented with ``"C"`` in the
+        result.
+    """
+
+    if "colors" not in df.columns:
+        raise KeyError("DataFrame must include a 'colors' column")
+
+    expanded = df.copy()
+    expanded["color"] = expanded["colors"].apply(lambda c: c if c else ["C"])
+    expanded = expanded.explode("color")
+
+    numeric_cols = expanded.select_dtypes(include="number").columns
+    return expanded.groupby("color")[numeric_cols].mean()
 
 
 if __name__ == "__main__":

--- a/tests/test_aggregation.py
+++ b/tests/test_aggregation.py
@@ -6,7 +6,7 @@ from pathlib import Path
 # Ensure the src package is importable when running this file directly
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from src.aggregation import by_set, by_color
+from src.aggregation import by_set, by_color, by_colors
 
 
 def test_by_set_groups_average():
@@ -29,3 +29,15 @@ def test_by_color_groups_average():
     result = result.sort_index()
     assert list(result.index) == ["R", "U"]
     assert result.loc["U", "vader_compound"] == pytest.approx(0.3)
+
+
+def test_by_colors_expands_lists_and_handles_colorless():
+    df = pd.DataFrame({
+        "colors": [["U"], ["U", "R"], []],
+        "vader_compound": [0.2, 0.4, 0.6],
+    })
+    result = by_colors(df).sort_index()
+    assert list(result.index) == ["C", "R", "U"]
+    assert result.loc["U", "vader_compound"] == pytest.approx((0.2 + 0.4) / 2)
+    assert result.loc["R", "vader_compound"] == pytest.approx(0.4)
+    assert result.loc["C", "vader_compound"] == pytest.approx(0.6)


### PR DESCRIPTION
## Summary
- expand aggregation helpers with `by_colors` for single card colors
- test new `by_colors` function

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685818ef85ec832c85e1868d7d08eea4