### PR TITLE
Add NRCLex tone classification

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ python main.py
 The script will:
 - load and clean card data
 - score flavor text sentiment
+- classify emotional tone with NRCLex
 - save results to `data/processed/sentiment_scores.csv`
 - aggregate sentiment by color and save to `data/processed/average_sentiment_by_color.csv`
 - create a chart in `reports/figures/average_polarity_by_color.png`

--- a/mtg_flavor_text_sentiment_analysis.md
+++ b/mtg_flavor_text_sentiment_analysis.md
@@ -27,7 +27,7 @@ Leverage natural language processing (NLP) techniques to analyze and visualize s
   - TextBlob (polarity, subjectivity)  
   - VADER (compound, positive, negative, neutral)
 - **3.2** Score each flavor text according to chosen tools.
-- **3.3** Optionally apply additional NLP models for humor detection or tone classification if feasible.
+- **3.3** Apply NRCLex to classify emotional tone for each flavor text.
 
 ### 4. Aggregation and Comparison
 - **4.1** Group sentiment scores by:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pandas
 textblob
 nltk
 matplotlib
+nrclex

--- a/src/sentiment.py
+++ b/src/sentiment.py
@@ -1,9 +1,10 @@
-"""Sentiment scoring utilities using TextBlob and VADER."""
+"""Sentiment scoring utilities using TextBlob, VADER and NRCLex."""
 
 from textblob import TextBlob
 from nltk.sentiment import SentimentIntensityAnalyzer
 import nltk
 from typing import Iterable, Dict
+from nrclex import NRCLex
 
 # Initialize VADER analyzer lazily
 _vader = None
@@ -18,18 +19,46 @@ def vader() -> SentimentIntensityAnalyzer:
     return _vader
 
 
-def score_text(text: str) -> Dict[str, float]:
-    """Return sentiment scores for a single string."""
+def _nrc_scores(text: str) -> Dict[str, float | str]:
+    """Return emotion scores using the NRC affect lexicon."""
+    emotions = NRCLex(text)
+    freq = emotions.affect_frequencies
+    categories = [
+        "anger",
+        "anticipation",
+        "disgust",
+        "fear",
+        "joy",
+        "negative",
+        "positive",
+        "sadness",
+        "surprise",
+        "trust",
+    ]
+    scores = {f"nrc_{c}": float(freq.get(c, 0.0)) for c in categories}
+    top_emotion = (
+        max(categories, key=lambda c: scores[f"nrc_{c}"])
+        if any(scores.values())
+        else "neutral"
+    )
+    scores["nrc_top_emotion"] = top_emotion
+    return scores
+
+
+def score_text(text: str) -> Dict[str, float | str]:
+    """Return sentiment and tone scores for a single string."""
     blob = TextBlob(text)
     tb_polarity = blob.sentiment.polarity
     vader_scores = vader().polarity_scores(text)
-    return {
+    scores = {
         "textblob_polarity": tb_polarity,
         "vader_compound": vader_scores["compound"],
         "vader_pos": vader_scores["pos"],
         "vader_neg": vader_scores["neg"],
         "vader_neu": vader_scores["neu"],
     }
+    scores.update(_nrc_scores(text))
+    return scores
 
 
 def score_texts(texts: Iterable[str]) -> list:

--- a/tests/test_sentiment.py
+++ b/tests/test_sentiment.py
@@ -20,3 +20,9 @@ def test_score_texts_multiple():
     assert isinstance(scores, list)
     assert len(scores) == 2
     assert set(scores[0]) == set(scores[1])
+
+
+def test_score_text_includes_nrc():
+    result = score_text("This card is amazing!")
+    assert "nrc_top_emotion" in result
+    assert isinstance(result["nrc_top_emotion"], str)


### PR DESCRIPTION
## Summary
- expand sentiment scoring to include NRCLex emotion detection
- require `nrclex` dependency
- test for NRCLex outputs
- document tone classification in README and project outline

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68581d7a820c832ca46261286d070e99