### PR TITLE
Add per-color aggregation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ The script will:
 - load and clean card data
 - score flavor text sentiment
 - save results to `data/processed/sentiment_scores.csv`
-- aggregate sentiment by color and save to `data/processed/average_sentiment_by_color.csv`
-- create a chart in `reports/figures/average_polarity_by_color.png`
+ - aggregate sentiment by single card colors and save to `data/processed/average_sentiment_by_color.csv`
+ - create a chart in `reports/figures/average_polarity_by_color.png`
 
 ## Viewing outputs
 

--- a/main.py
+++ b/main.py
@@ -6,7 +6,7 @@ import matplotlib.pyplot as plt
 
 from src.acquisition import load_and_clean_cards
 from src.sentiment import score_texts
-from src.aggregation import by_set, by_color
+from src.aggregation import by_set, by_colors
 from src.visualization import plot_average_sentiment
 
 
@@ -60,7 +60,7 @@ def run_pipeline(raw_path: Path | None = None) -> None:
         "vader_neg",
         "vader_neu",
     ]
-    df_by_color = by_color(df[["color_identity"] + metrics])
+    df_by_color = by_colors(df[["colors"] + metrics])
     agg_path = processed_dir / "average_sentiment_by_color.csv"
     df_by_color.to_csv(agg_path)
     print(f"Saved aggregation to {agg_path}")
@@ -68,7 +68,9 @@ def run_pipeline(raw_path: Path | None = None) -> None:
     print("Generating figure ...")
     fig_path = Path("reports/figures/average_polarity_by_color.png")
     fig_path.parent.mkdir(parents=True, exist_ok=True)
-    plot_average_sentiment(df, group="color_identity", metric="textblob_polarity")
+    expanded = df.assign(color=df["colors"].apply(lambda c: c if c else ["C"]))
+    expanded = expanded.explode("color")
+    plot_average_sentiment(expanded, group="color", metric="textblob_polarity")
     plt.savefig(fig_path)
     plt.close()
     print(f"Saved figure to {fig_path}")

--- a/scripts/aggregate_results.py
+++ b/scripts/aggregate_results.py
@@ -7,7 +7,7 @@ sys.path.append(str(repo_root))
 
 import pandas as pd
 
-from src.aggregation import by_set, by_color
+from src.aggregation import by_set, by_colors
 
 
 def main() -> None:
@@ -28,7 +28,7 @@ def main() -> None:
     ]
 
     df_by_set = by_set(df[["set_code"] + metrics])
-    df_by_color = by_color(df[["color_identity"] + metrics])
+    df_by_color = by_colors(df[["colors"] + metrics])
 
     print("Average sentiment by set:\n", df_by_set.head(), sep="")
     print("\nAverage sentiment by color:\n", df_by_color.head(), sep="")

--- a/src/aggregation.py
+++ b/src/aggregation.py
@@ -1,7 +1,6 @@
 """Aggregation helpers for analyzing sentiment statistics."""
 
 import pandas as pd
-from typing import Iterable, Dict
 
 
 def by_set(df: pd.DataFrame) -> pd.DataFrame:
@@ -12,6 +11,33 @@ def by_set(df: pd.DataFrame) -> pd.DataFrame:
 def by_color(df: pd.DataFrame) -> pd.DataFrame:
     """Return average sentiment metrics grouped by color identity."""
     return df.groupby("color_identity").mean()
+
+
+def by_colors(df: pd.DataFrame) -> pd.DataFrame:
+    """Return average sentiment metrics grouped by individual card color.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        DataFrame containing a ``colors`` column with lists of color letters.
+        Empty lists indicate colorless cards, represented with ``"C"`` in the
+        result. Colors are ordered ``["B", "U", "G", "R", "W", "C"]`` so the
+        returned ``DataFrame`` always has exactly one row per color.
+    """
+
+    if "colors" not in df.columns:
+        raise KeyError("DataFrame must include a 'colors' column")
+
+    expanded = df.copy()
+    expanded["color"] = expanded["colors"].apply(lambda c: c if c else ["C"])
+    expanded = expanded.explode("color")
+
+    numeric_cols = expanded.select_dtypes(include="number").columns
+
+    # Ensure all six colors are present in a predictable order
+    order = ["B", "U", "G", "R", "W", "C"]
+    grouped = expanded.groupby("color")[numeric_cols].mean()
+    return grouped.reindex(order)
 
 
 if __name__ == "__main__":

--- a/tests/test_aggregation.py
+++ b/tests/test_aggregation.py
@@ -6,7 +6,7 @@ from pathlib import Path
 # Ensure the src package is importable when running this file directly
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from src.aggregation import by_set, by_color
+from src.aggregation import by_set, by_color, by_colors
 
 
 def test_by_set_groups_average():
@@ -29,3 +29,17 @@ def test_by_color_groups_average():
     result = result.sort_index()
     assert list(result.index) == ["R", "U"]
     assert result.loc["U", "vader_compound"] == pytest.approx(0.3)
+
+
+def test_by_colors_expands_lists_and_handles_colorless():
+    df = pd.DataFrame({
+        "colors": [["U"], ["U", "R"], []],
+        "vader_compound": [0.2, 0.4, 0.6],
+    })
+    result = by_colors(df)
+    expected_order = ["B", "U", "G", "R", "W", "C"]
+    assert list(result.index) == expected_order
+    assert result.loc["U", "vader_compound"] == pytest.approx((0.2 + 0.4) / 2)
+    assert result.loc["R", "vader_compound"] == pytest.approx(0.4)
+    assert result.loc["C", "vader_compound"] == pytest.approx(0.6)
+    assert pd.isna(result.loc["B", "vader_compound"])

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -34,14 +34,14 @@ def test_run_pipeline_redownloads(tmp_path, monkeypatch):
             path.unlink()
             raise FileNotFoundError
         # second attempt should succeed
-        return [{"flavorText": "test", "color_identity": "U"}]
+        return [{"flavorText": "test", "color_identity": "U", "colors": ["U"]}]
 
     # patch helpers
     monkeypatch.setattr(main, "download_all_printings", fake_download)
     monkeypatch.setattr(main, "load_and_clean_cards", fake_load_and_clean)
     monkeypatch.setattr(main, "score_texts", lambda texts: [{"textblob_polarity":0, "vader_compound":0,
                                                              "vader_pos":0, "vader_neg":0, "vader_neu":0} for _ in texts])
-    monkeypatch.setattr(main, "by_color", lambda df: pd.DataFrame())
+    monkeypatch.setattr(main, "by_colors", lambda df: pd.DataFrame())
     monkeypatch.setattr(main, "plot_average_sentiment", lambda *a, **k: None)
 
     main.run_pipeline(raw_path=raw_path)


### PR DESCRIPTION
## Summary
- expand aggregation helpers with `by_colors` for single card colors
- test new `by_colors` function
- ensure pipelines and scripts use new helper

## Testing
- `pytest tests/test_aggregation.py::test_by_colors_expands_lists_and_handles_colorless -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685818ef85ec832c85e1868d7d08eea4